### PR TITLE
fix: bluesky profile link stretching

### DIFF
--- a/web/src/css/profile.css
+++ b/web/src/css/profile.css
@@ -78,6 +78,7 @@
   border-radius: var(--radius-sm);
   background: rgba(59, 130, 246, 0.1);
   transition: all 0.15s ease;
+  width: fit-content;
 }
 
 .profile-bluesky-link:hover {


### PR DESCRIPTION
before:
<img width="644" height="157" alt="image" src="https://github.com/user-attachments/assets/f1acc558-702a-4ba4-ba45-438f8962ce09" />

after:
<img width="429" height="145" alt="image" src="https://github.com/user-attachments/assets/faea2060-3459-46cf-a5b0-4f5402f15f5f" />
