### PR TITLE
fix: button text line wrapping

### DIFF
--- a/web/src/css/buttons.css
+++ b/web/src/css/buttons.css
@@ -8,6 +8,7 @@
   font-weight: 500;
   border-radius: var(--radius-md);
   transition: all 0.15s ease;
+  white-space: pre;
 }
 
 .btn-primary {


### PR DESCRIPTION
before:
<img width="644" height="157" alt="image" src="https://github.com/user-attachments/assets/743291bb-7ecc-439c-a17d-721039aa737f" />

after:
<img width="644" height="157" alt="image" src="https://github.com/user-attachments/assets/4bfed4eb-fa24-4bad-8cba-df4ca4d68014" />
