### PR TITLE
Fix the highlight context menu action in Firefox

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -71,6 +71,13 @@ async function createHighlight(payload) {
   return res.json();
 }
 
+function refreshTabAnnotations(tabId) {
+  if (!tabId) return;
+  chrome.tabs.sendMessage(tabId, { type: "REFRESH_ANNOTATIONS" }).catch(() => {
+    /* ignore missing content script */
+  });
+}
+
 async function openAnnotationUI(tabId, windowId) {
   if (hasSidePanel) {
     try {
@@ -273,6 +280,7 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
           selector: selector,
         });
         showNotification("Margin", "Text highlighted!");
+        refreshTabAnnotations(tab.id);
       } catch (err) {
         console.error("Highlight API error:", err);
         if (err?.message === "Not authenticated") {
@@ -515,6 +523,7 @@ async function handleMessage(request, sender, sendResponse) {
             color: request.data.color || "yellow",
           });
           sendResponse({ success: true, data: highlightData });
+          refreshTabAnnotations(sender.tab?.id);
         } catch (error) {
           sendResponse({ success: false, error: error.message });
         }

--- a/extension/content/content.js
+++ b/extension/content/content.js
@@ -986,6 +986,12 @@
       return true;
     }
 
+    if (request.type === "REFRESH_ANNOTATIONS") {
+      fetchAnnotations();
+      sendResponse({ success: true });
+      return true;
+    }
+
     if (request.type === "UPDATE_OVERLAY_VISIBILITY") {
       if (sidebarHost) {
         sidebarHost.style.display = request.show ? "block" : "none";


### PR DESCRIPTION
Good morning!

This PR fixes a couple issues with the highlight mechanism in Firefox:

- The service worker wasn't handling the client script's call to highlight text.
- The API call the service worker would have run (if the above was handled) wasn't authenticated.
- Highlighting text successfully didn't trigger a refresh like annotating does, so highlights wouldn't show up until after a page refresh.

Additionally, the context menu wasn't showing up after reloading the temp extension; this PR includes a fix that ensures that gets registered for future testing.

I don't see any automated tests for the extension code, so I tried my best to make sure I didn't introduce any weird behavior in Chrome, but I was unable to fully test it out.

Hope this helps!

Closes #11 