### PR TITLE
Extension shortcut toggles sidebar instead of just open

### DIFF
--- a/extension/src/entrypoints/sidepanel/main.tsx
+++ b/extension/src/entrypoints/sidepanel/main.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { browser } from 'wxt/browser';
 import App from '@/components/sidepanel/App';
 import '@/assets/styles.css';
+
+// Connect a port so the background script can track open/closed state
+browser.runtime.connect({ name: 'sidepanel' });
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -40,12 +40,12 @@ export default defineConfig({
         128: '/icons/icon-128.png',
       },
       commands: {
-        'open-sidebar': {
+        'toggle-sidebar': {
           suggested_key: {
             default: 'Alt+M',
             mac: 'Alt+M',
           },
-          description: 'Open Margin sidebar',
+          description: 'Toggle Margin sidebar',
         },
         'annotate-selection': {
           suggested_key: {


### PR DESCRIPTION
Updates the `alt+m` keyboard shortcut to toggle the sidebar instead of only opening it.

Verified by
1. `cd extension && npm run dev`
2. Testing the shortcut, observing it toggle open and close