### PR TITLE
fix: update GitHub links from `margin-at` to `paddinglabs`

### DIFF
--- a/web/src/components/navigation/RightSidebar.tsx
+++ b/web/src/components/navigation/RightSidebar.tsx
@@ -274,7 +274,7 @@ export default function RightSidebar({ onNavigate }: RightSidebarProps) {
               Terms
             </a>
             <a
-              href="https://github.com/margin-at/margin"
+              href="https://github.com/paddinglabs/margin"
               target="_blank"
               rel="noreferrer"
               className="hover:underline hover:text-surface-600 dark:hover:text-surface-300"

--- a/web/src/views/About.tsx
+++ b/web/src/views/About.tsx
@@ -293,7 +293,7 @@ function LexiconBlock() {
             {copied ? "Copied" : "Copy"}
           </button>
           <a
-            href="https://github.com/margin-at/margin/blob/main/lexicons/at/margin/note.json"
+            href="https://github.com/paddinglabs/margin/blob/main/lexicons/at/margin/note.json"
             target="_blank"
             rel="noreferrer"
             className="inline-flex items-center gap-1 hover:text-surface-300 transition-colors"
@@ -617,7 +617,7 @@ export default function About() {
 
             <aside className="lg:pt-12 flex flex-col gap-3 self-start">
               <a
-                href="https://github.com/margin-at"
+                href="https://github.com/paddinglabs"
                 target="_blank"
                 rel="noreferrer"
                 className="inline-flex items-center justify-between gap-3 text-[13px] font-medium text-surface-600 dark:text-surface-400 hover:text-surface-900 dark:hover:text-white transition-colors py-1.5 border-b border-surface-200 dark:border-surface-800"
@@ -715,7 +715,7 @@ export default function About() {
               />
             </a>
             <a
-              href="https://github.com/margin-at"
+              href="https://github.com/paddinglabs"
               target="_blank"
               rel="noreferrer"
               className="inline-flex items-center gap-1.5 text-[14px] font-medium text-surface-500 dark:text-surface-400 hover:text-surface-900 dark:hover:text-white transition-colors"


### PR DESCRIPTION
Hello 🙂 I noticed that the About page has a broken link to `https://github.com/margin-at`. This is because GitHub redirects old repository links, but not organization links.

This PR fixes this by replacing all instances of the `margin-at` org name with the new one, `paddinglabs`, to avoid relying on redirects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated external repository links across the application to point to the new GitHub organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->